### PR TITLE
Create variant macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# `impl_trait_utils`
+# impl-trait-utils
 
 Utilities for working with impl traits in Rust.
 
-## `trait_transformer`
+## `make_variant`
 
-Trait transformer is an experimental crate that generates specialized versions of a base trait. For example, if you want a `Send`able version of your trait, you'd write:
+`make_variant` generates a specialized version of a base trait that uses `async fn` and/or `-> impl Trait`. For example, if you want a `Send`able version of your trait, you'd write:
 
 ```rust
-#[trait_transformer(SendIntFactory: Send)]
+#[trait_transformer::make_variant(SendIntFactory: Send)]
 trait IntFactory {
     async fn make(&self) -> i32;
     // ..or..
@@ -16,7 +16,13 @@ trait IntFactory {
 }
 ```
 
-Which creates a new `SendIntFactory: IntFactory + Send` trait and additionally bounds `SendIntFactory::make(): Send` and `SendIntFactory::stream(): Send`. The generated sytax is still experimental, as it relies on the nightly and unstable `async_fn_in_trait`, `return_position_impl_trait_in_trait`, and `return_type_notation` features.
+Which creates a new `SendIntFactory: IntFactory + Send` trait and additionally bounds `SendIntFactory::make(): Send` and `SendIntFactory::stream(): Send`. Ordinary methods are not affected.
+
+Implementers of the trait can choose to implement the variant instead of the original trait. The macro creates a blanket impl which ensures that any type which implements the variant also implements the original trait.
+
+## `trait_transformer`
+
+`trait_transformer` does the same thing as `make_variant`, but using experimental nightly-only syntax that depends on the `return_type_notation` feature. It may be used to experiment with new kinds of trait transformations in the future.
 
 #### License and usage notes
 

--- a/trait_transformer/examples/variant.rs
+++ b/trait_transformer/examples/variant.rs
@@ -8,9 +8,9 @@
 
 use std::future::Future;
 
-use trait_transformer::variant;
+use trait_transformer::make_variant;
 
-#[variant(SendIntFactory: Send)]
+#[make_variant(SendIntFactory: Send)]
 trait IntFactory {
     const NAME: &'static str;
 

--- a/trait_transformer/examples/variant.rs
+++ b/trait_transformer/examples/variant.rs
@@ -6,14 +6,22 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::future::Future;
+
 use trait_transformer::variant;
 
 #[variant(SendIntFactory: Send)]
 trait IntFactory {
-    async fn make(&self) -> i32;
-    // ..or..
+    const NAME: &'static str;
+
+    type MyFut<'a>: Future
+    where
+        Self: 'a;
+
+    async fn make(&self, x: u32, y: &str) -> i32;
     fn stream(&self) -> impl Iterator<Item = i32>;
     fn call(&self) -> u32;
+    fn another_async(&self, input: Result<(), &str>) -> Self::MyFut<'_>;
 }
 
 fn main() {}

--- a/trait_transformer/examples/variant.rs
+++ b/trait_transformer/examples/variant.rs
@@ -1,0 +1,19 @@
+// Copyright (c) 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use trait_transformer::variant;
+
+#[variant(SendIntFactory: Send)]
+trait IntFactory {
+    async fn make(&self) -> i32;
+    // ..or..
+    fn stream(&self) -> impl Iterator<Item = i32>;
+    fn call(&self) -> u32;
+}
+
+fn main() {}

--- a/trait_transformer/src/lib.rs
+++ b/trait_transformer/src/lib.rs
@@ -7,6 +7,7 @@
 // except according to those terms.
 
 mod transformer;
+mod variant;
 
 #[proc_macro_attribute]
 pub fn trait_transformer(
@@ -14,4 +15,12 @@ pub fn trait_transformer(
     item: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
     transformer::trait_transformer(attr, item)
+}
+
+#[proc_macro_attribute]
+pub fn variant(
+    attr: proc_macro::TokenStream,
+    item: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    variant::variant(attr, item)
 }

--- a/trait_transformer/src/lib.rs
+++ b/trait_transformer/src/lib.rs
@@ -18,9 +18,9 @@ pub fn trait_transformer(
 }
 
 #[proc_macro_attribute]
-pub fn variant(
+pub fn make_variant(
     attr: proc_macro::TokenStream,
     item: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
-    variant::variant(attr, item)
+    variant::make_variant(attr, item)
 }

--- a/trait_transformer/src/lib.rs
+++ b/trait_transformer/src/lib.rs
@@ -6,6 +6,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![doc = include_str!("../../README.md")]
+
 mod transformer;
 mod variant;
 

--- a/trait_transformer/src/variant.rs
+++ b/trait_transformer/src/variant.rs
@@ -6,15 +6,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::iter;
+
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{
     parse::{Parse, ParseStream},
     parse_macro_input,
     punctuated::Punctuated,
-    token::Comma,
-    Ident, ItemTrait, Path, Result, ReturnType, Token, TraitBound, TraitBoundModifier, TraitItem,
-    Type,
+    token::Plus,
+    Ident, ItemTrait, Result, ReturnType, Signature, Token, TraitBound, TraitItem, TraitItemFn,
+    Type, TypeImplTrait, TypeParamBound,
 };
 
 struct Attrs {
@@ -33,7 +35,7 @@ struct Variant {
     name: Ident,
     #[allow(unused)]
     colon: Token![:],
-    supertrait: Path,
+    bounds: Punctuated<TraitBound, Plus>,
 }
 
 impl Parse for Variant {
@@ -41,7 +43,7 @@ impl Parse for Variant {
         Ok(Self {
             name: input.parse()?,
             colon: input.parse()?,
-            supertrait: input.parse()?,
+            bounds: input.parse_terminated(TraitBound::parse, Token![+])?,
         })
     }
 }
@@ -53,5 +55,76 @@ pub fn variant(
     let attrs = parse_macro_input!(attr as Attrs);
     let item = parse_macro_input!(item as ItemTrait);
 
-    quote! {}.into()
+    let variant = make_variant(&attrs, &item);
+    let output = quote! {
+        #item
+        #variant
+    };
+
+    output.into()
+}
+
+fn make_variant(attrs: &Attrs, tr: &ItemTrait) -> TokenStream {
+    let Variant {
+        ref name,
+        colon: _,
+        ref bounds,
+    } = attrs.variant;
+    let bounds: Vec<_> = bounds
+        .into_iter()
+        .map(|b| TypeParamBound::Trait(b.clone()))
+        .collect();
+    let variant = ItemTrait {
+        ident: name.clone(),
+        supertraits: tr.supertraits.iter().chain(&bounds).cloned().collect(),
+        items: tr
+            .items
+            .iter()
+            .map(|item| transform_item(item, &bounds))
+            .collect(),
+        ..tr.clone()
+    };
+    quote! { #variant }
+}
+
+fn transform_item(item: &TraitItem, bounds: &Vec<TypeParamBound>) -> TraitItem {
+    let TraitItem::Fn(fn_item @ TraitItemFn { sig, .. }) = item else {
+        return item.clone();
+    };
+    let (arrow, output) = if sig.asyncness.is_some() {
+        let orig = match &sig.output {
+            ReturnType::Default => quote! { () },
+            ReturnType::Type(_, ty) => quote! { #ty },
+        };
+        let future = syn::parse2(quote! { ::core::future::Future<Output = #orig> }).unwrap();
+        let ty = Type::ImplTrait(TypeImplTrait {
+            impl_token: syn::parse2(quote! { impl }).unwrap(),
+            bounds: iter::once(TypeParamBound::Trait(future))
+                .chain(bounds.iter().cloned())
+                .collect(),
+        });
+        (syn::parse2(quote! { -> }).unwrap(), ty)
+    } else {
+        match &sig.output {
+            ReturnType::Type(arrow, ty) => match &**ty {
+                Type::ImplTrait(it) => {
+                    let ty = Type::ImplTrait(TypeImplTrait {
+                        impl_token: it.impl_token.clone(),
+                        bounds: it.bounds.iter().chain(bounds).cloned().collect(),
+                    });
+                    (arrow.clone(), ty)
+                }
+                _ => return item.clone(),
+            },
+            ReturnType::Default => return item.clone(),
+        }
+    };
+    TraitItem::Fn(TraitItemFn {
+        sig: Signature {
+            asyncness: None,
+            output: ReturnType::Type(arrow, Box::new(output)),
+            ..sig.clone()
+        },
+        ..fn_item.clone()
+    })
 }

--- a/trait_transformer/src/variant.rs
+++ b/trait_transformer/src/variant.rs
@@ -1,0 +1,57 @@
+// Copyright (c) 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{
+    parse::{Parse, ParseStream},
+    parse_macro_input,
+    punctuated::Punctuated,
+    token::Comma,
+    Ident, ItemTrait, Path, Result, ReturnType, Token, TraitBound, TraitBoundModifier, TraitItem,
+    Type,
+};
+
+struct Attrs {
+    variant: Variant,
+}
+
+impl Parse for Attrs {
+    fn parse(input: ParseStream) -> Result<Self> {
+        Ok(Self {
+            variant: Variant::parse(input)?,
+        })
+    }
+}
+
+struct Variant {
+    name: Ident,
+    #[allow(unused)]
+    colon: Token![:],
+    supertrait: Path,
+}
+
+impl Parse for Variant {
+    fn parse(input: ParseStream) -> Result<Self> {
+        Ok(Self {
+            name: input.parse()?,
+            colon: input.parse()?,
+            supertrait: input.parse()?,
+        })
+    }
+}
+
+pub fn variant(
+    attr: proc_macro::TokenStream,
+    item: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    let attrs = parse_macro_input!(attr as Attrs);
+    let item = parse_macro_input!(item as ItemTrait);
+
+    quote! {}.into()
+}

--- a/trait_transformer/src/variant.rs
+++ b/trait_transformer/src/variant.rs
@@ -126,10 +126,10 @@ fn transform_item(item: &TraitItem, bounds: &Vec<TypeParamBound>) -> TraitItem {
             ReturnType::Type(arrow, ty) => match &**ty {
                 Type::ImplTrait(it) => {
                     let ty = Type::ImplTrait(TypeImplTrait {
-                        impl_token: it.impl_token.clone(),
+                        impl_token: it.impl_token,
                         bounds: it.bounds.iter().chain(bounds).cloned().collect(),
                     });
-                    (arrow.clone(), ty)
+                    (*arrow, ty)
                 }
                 _ => return item.clone(),
             },


### PR DESCRIPTION
This takes an input like this:

```rust
#[variant(SendIntFactory: Send)]
trait IntFactory {
    async fn make(&self, x: u32, y: &str) -> i32;
    fn stream(&self) -> impl Iterator<Item = i32>;
    fn call(&self) -> u32;
}
```

And creates an additional trait with the specified bounds:

```rust
trait SendIntFactory: Send {
    fn make(&self, x: u32, y: &str) -> impl ::core::future::Future<Output = i32> + Send;
    fn stream(&self) -> impl Iterator<Item = i32> + Send;
    fn call(&self) -> u32;
}
```

And a blanket impl, so the implementer only has to implement one trait:

```rust
impl<T> IntFactory for T
where
    T: SendIntFactory,
{
    async fn make(&self, x: u32, y: &str) -> i32 {
        <Self as SendIntFactory>::make(self, x, y).await
    }
    fn stream(&self) -> impl Iterator<Item = i32> {
        <Self as SendIntFactory>::stream(self)
    }
    fn call(&self) -> u32 {
        <Self as SendIntFactory>::call(self)
    }
}
```

After brainstorming a handful of options I settled on `variant` as the most self-explanatory name for what this macro does. It does unfortunately conflict with enum variants, but I don't think that will actually be confusing in context.

My hope is that this will be forward-compatible with both RTN and implementable trait aliases, [as described here](https://rust-lang.zulipchat.com/#narrow/stream/315482-t-compiler.2Fetc.2Fopaque-types/topic/Migration.20path.20to.20trait.20aliases.20and.20RTN/near/392588237).