### PR TITLE
allow(async_fn_in_trait) on traits with Send variant

### DIFF
--- a/trait-variant/examples/variant.rs
+++ b/trait-variant/examples/variant.rs
@@ -10,8 +10,8 @@ use std::future::Future;
 
 use trait_variant::make_variant;
 
-#[make_variant(SendIntFactory: Send)]
-trait IntFactory {
+#[make_variant(IntFactory: Send)]
+pub trait LocalIntFactory {
     const NAME: &'static str;
 
     type MyFut<'a>: Future
@@ -22,6 +22,13 @@ trait IntFactory {
     fn stream(&self) -> impl Iterator<Item = i32>;
     fn call(&self) -> u32;
     fn another_async(&self, input: Result<(), &str>) -> Self::MyFut<'_>;
+}
+
+#[allow(dead_code)]
+fn spawn_task(factory: impl IntFactory + 'static) {
+    tokio::spawn(async move {
+        let _int = factory.make(1, "foo").await;
+    });
 }
 
 fn main() {}

--- a/trait-variant/src/variant.rs
+++ b/trait-variant/src/variant.rs
@@ -60,7 +60,7 @@ pub fn make_variant(
         .variant
         .bounds
         .iter()
-        .any(|b| b.path.segments.last().unwrap().ident.to_string() == "Send")
+        .any(|b| b.path.segments.last().unwrap().ident == "Send")
     {
         quote! { #[allow(async_fn_in_trait)] }
     } else {


### PR DESCRIPTION
If the user is using this macro then they aren't in danger of publishing a trait 
incompatible with work-stealing executors.
