### PR TITLE
Shorten name to trait_variant::make

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 Utilities for working with impl traits in Rust.
 
-## `make_variant`
+## `trait_variant`
 
-`make_variant` generates a specialized version of a base trait that uses `async fn` and/or `-> impl Trait`. For example, if you want a `Send`able version of your trait, you'd write:
+`trait_variant` generates a specialized version of a base trait that uses `async fn` and/or `-> impl Trait`. For example, if you want a `Send`able version of your trait, you'd write:
 
 ```rust
-#[trait_variant::make_variant(SendIntFactory: Send)]
+#[trait_variant::make(SendIntFactory: Send)]
 trait IntFactory {
     async fn make(&self) -> i32;
     // ..or..
@@ -22,7 +22,7 @@ Implementers of the trait can choose to implement the variant instead of the ori
 
 ## `trait_transformer`
 
-`trait_transformer` does the same thing as `make_variant`, but using experimental nightly-only syntax that depends on the `return_type_notation` feature. It may be used to experiment with new kinds of trait transformations in the future.
+`trait_transformer` does the same thing as `make`, but using experimental nightly-only syntax that depends on the `return_type_notation` feature. It may be used to experiment with new kinds of trait transformations in the future.
 
 #### License and usage notes
 

--- a/trait-variant/examples/variant.rs
+++ b/trait-variant/examples/variant.rs
@@ -10,8 +10,8 @@ use std::future::Future;
 
 use trait_variant::make_variant;
 
-#[make_variant(SendIntFactory: Send)]
-trait IntFactory {
+#[make_variant(IntFactory: Send)]
+pub trait LocalIntFactory {
     const NAME: &'static str;
 
     type MyFut<'a>: Future
@@ -22,6 +22,13 @@ trait IntFactory {
     fn stream(&self) -> impl Iterator<Item = i32>;
     fn call(&self) -> u32;
     fn another_async(&self, input: Result<(), &str>) -> Self::MyFut<'_>;
+}
+
+#[allow(dead_code)]
+fn spawn_task(factory: impl IntFactory + 'static) {
+    tokio::spawn(async move {
+        let _int = factory.make(1, "foo").await;
+    });
 }
 
 fn main() {}

--- a/trait-variant/examples/variant.rs
+++ b/trait-variant/examples/variant.rs
@@ -8,9 +8,7 @@
 
 use std::future::Future;
 
-use trait_variant::make_variant;
-
-#[make_variant(IntFactory: Send)]
+#[trait_variant::make(IntFactory: Send)]
 pub trait LocalIntFactory {
     const NAME: &'static str;
 

--- a/trait-variant/src/lib.rs
+++ b/trait-variant/src/lib.rs
@@ -20,9 +20,9 @@ pub fn trait_transformer(
 }
 
 #[proc_macro_attribute]
-pub fn make_variant(
+pub fn make(
     attr: proc_macro::TokenStream,
     item: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
-    variant::make_variant(attr, item)
+    variant::make(attr, item)
 }

--- a/trait-variant/src/variant.rs
+++ b/trait-variant/src/variant.rs
@@ -49,7 +49,7 @@ impl Parse for MakeVariant {
     }
 }
 
-pub fn make_variant(
+pub fn make(
     attr: proc_macro::TokenStream,
     item: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {


### PR DESCRIPTION
I'm not happy at all with the current name, having two underscore and 
repeating itself. After some discussion in Zulip, this is the one I 
arrived at. Since the name of the macro doesn't stand on its own, 
`trait_variant::make` will the be standard way to invoke it.

Depends on #6 to avoid conflicts.
