### PR TITLE
Fix associated type generic bounds not in where clause

### DIFF
--- a/trait-variant/examples/variant.rs
+++ b/trait-variant/examples/variant.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::future::Future;
+use std::{future::Future, ops::Add};
 
 #[trait_variant::make(IntFactory: Send)]
 pub trait LocalIntFactory {
@@ -36,6 +36,8 @@ where
 {
     const CONST: usize = 3;
     type F;
+    type A<const ANOTHER_CONST: u8>;
+    type B<T>: Add<T>;
 
     async fn take(&self, s: S);
 }

--- a/trait-variant/examples/variant.rs
+++ b/trait-variant/examples/variant.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::{future::Future, ops::Add};
+use std::{fmt::Display, future::Future};
 
 #[trait_variant::make(IntFactory: Send)]
 pub trait LocalIntFactory {
@@ -37,9 +37,10 @@ where
     const CONST: usize = 3;
     type F;
     type A<const ANOTHER_CONST: u8>;
-    type B<T>: Add<T>;
+    type B<T: Display>: FromIterator<T>;
 
     async fn take(&self, s: S);
+    fn build<T: Display>(&self, items: impl Iterator<Item = T>) -> Self::B<T>;
 }
 
 fn main() {}

--- a/trait-variant/src/variant.rs
+++ b/trait-variant/src/variant.rs
@@ -15,9 +15,9 @@ use syn::{
     parse_macro_input,
     punctuated::Punctuated,
     token::{Comma, Plus},
-    Error, FnArg, GenericParam, Generics, Ident, ItemTrait, Lifetime, Pat, PatType, Result,
-    ReturnType, Signature, Token, TraitBound, TraitItem, TraitItemConst, TraitItemFn,
-    TraitItemType, Type, TypeImplTrait, TypeParamBound,
+    Error, FnArg, GenericParam, Ident, ItemTrait, Lifetime, Pat, PatType, Result, ReturnType,
+    Signature, Token, TraitBound, TraitItem, TraitItemConst, TraitItemFn, TraitItemType, Type,
+    TypeImplTrait, TypeParamBound,
 };
 
 struct Attrs {
@@ -256,17 +256,11 @@ fn blanket_impl_item(
             }
         }
         TraitItem::Type(TraitItemType {
-            ident,
-            generics:
-                Generics {
-                    params,
-                    where_clause,
-                    ..
-                },
-            ..
+            ident, generics, ..
         }) => {
+            let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
             quote! {
-                type #ident<#params> = <Self as #variant<#generic_names>>::#ident<#params> #where_clause;
+                type #ident #impl_generics = <Self as #variant<#generic_names>>::#ident #ty_generics #where_clause;
             }
         }
         _ => Error::new_spanned(item, "unsupported item type").into_compile_error(),


### PR DESCRIPTION
Resolves #25.

Also includes a minor refactor of `mk_blanket_impl` to prefer the use of [`split_for_impl`](https://jeltef.github.io/derive_more/syn/struct.Generics.html#method.split_for_impl) over `GenericParamName`.