### PR TITLE
Support omitting the variant name

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,17 @@ trait IntFactory: Send {
 
 Implementers can choose to implement either `LocalIntFactory` or `IntFactory` as appropriate.
 
+If a non-`Send` variant of the trait is not needed, the name of the new variant can simply be omitted.  E.g., this generates a *single* (rather than an additional) trait whose definition matches that in the expansion above:
+
+```rust
+#[trait_variant::make(Send)]
+trait IntFactory {
+    async fn make(&self) -> i32;
+    fn stream(&self) -> impl Iterator<Item = i32>;
+    fn call(&self) -> u32;
+}
+```
+
 For more details, see the docs for [`trait_variant::make`].
 
 [`trait_variant::make`]: https://docs.rs/trait-variant/latest/trait_variant/attr.make.html

--- a/trait-variant/examples/variant.rs
+++ b/trait-variant/examples/variant.rs
@@ -29,6 +29,11 @@ fn spawn_task(factory: impl IntFactory + 'static) {
     });
 }
 
+#[trait_variant::make(Send)]
+pub trait TupleFactory {
+    async fn new() -> Self;
+}
+
 #[trait_variant::make(GenericTrait: Send)]
 pub trait LocalGenericTrait<'x, S: Sync, Y, const X: usize>
 where

--- a/trait-variant/src/lib.rs
+++ b/trait-variant/src/lib.rs
@@ -38,6 +38,19 @@ mod variant;
 /// Implementers of the trait can choose to implement the variant instead of the
 /// original trait. The macro creates a blanket impl which ensures that any type
 /// which implements the variant also implements the original trait.
+///
+/// If a non-`Send` variant of the trait is not needed, the name of
+/// new variant can simply be omitted.  E.g., this generates a
+/// *single* (rather than an additional) trait whose definition
+/// matches that in the expansion above:
+///
+/// #[trait_variant::make(Send)]
+/// trait IntFactory {
+///     async fn make(&self) -> i32;
+///     fn stream(&self) -> impl Iterator<Item = i32>;
+///     fn call(&self) -> u32;
+/// }
+/// ```
 #[proc_macro_attribute]
 pub fn make(
     attr: proc_macro::TokenStream,

--- a/trait-variant/tests/bounds.rs
+++ b/trait-variant/tests/bounds.rs
@@ -1,0 +1,65 @@
+// Copyright (c) 2023 Google LLC
+// Copyright (c) 2023 Various contributors (see git history)
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[trait_variant::make(Send + Sync)]
+pub trait Trait {
+    const CONST: &'static ();
+    type Gat<'a>
+    where
+        Self: 'a;
+    async fn assoc_async_fn_no_ret(a: (), b: ());
+    async fn assoc_async_method_no_ret(&self, a: (), b: ());
+    async fn assoc_async_fn(a: (), b: ()) -> ();
+    async fn assoc_async_method(&self, a: (), b: ()) -> ();
+    fn assoc_sync_fn_no_ret(a: (), b: ());
+    fn assoc_sync_method_no_ret(&self, a: (), b: ());
+    fn assoc_sync_fn(a: (), b: ()) -> ();
+    fn assoc_sync_method(&self, a: (), b: ()) -> ();
+    // FIXME: See #17.
+    //async fn dft_assoc_async_fn_no_ret(_a: (), _b: ()) {}
+    //async fn dft_assoc_async_method_no_ret(&self, _a: (), _b: ()) {}
+    //async fn dft_assoc_async_fn(_a: (), _b: ()) -> () {}
+    //async fn dft_assoc_async_method(&self, _a: (), _b: ()) -> () {}
+    fn dft_assoc_sync_fn_no_ret(_a: (), _b: ()) {}
+    fn dft_assoc_sync_method_no_ret(&self, _a: (), _b: ()) {}
+    fn dft_assoc_sync_fn(_a: (), _b: ()) -> () {}
+    fn dft_assoc_sync_method(&self, _a: (), _b: ()) -> () {}
+}
+
+impl Trait for () {
+    const CONST: &'static () = &();
+    type Gat<'a> = ();
+    async fn assoc_async_fn_no_ret(_a: (), _b: ()) {}
+    async fn assoc_async_method_no_ret(&self, _a: (), _b: ()) {}
+    async fn assoc_async_fn(_a: (), _b: ()) -> () {}
+    async fn assoc_async_method(&self, _a: (), _b: ()) -> () {}
+    fn assoc_sync_fn_no_ret(_a: (), _b: ()) {}
+    fn assoc_sync_method_no_ret(&self, _a: (), _b: ()) {}
+    fn assoc_sync_fn(_a: (), _b: ()) -> () {}
+    fn assoc_sync_method(&self, _a: (), _b: ()) -> () {}
+}
+
+fn is_bounded<T: Send + Sync>(_: T) {}
+
+#[test]
+fn test() {
+    fn inner<T: Trait>(x: T) {
+        let (a, b) = ((), ());
+        is_bounded(<T as Trait>::assoc_async_fn_no_ret(a, b));
+        is_bounded(<T as Trait>::assoc_async_method_no_ret(&x, a, b));
+        is_bounded(<T as Trait>::assoc_async_fn(a, b));
+        is_bounded(<T as Trait>::assoc_async_method(&x, a, b));
+        // FIXME: See #17.
+        //is_bounded(<T as Trait>::dft_assoc_async_fn_no_ret(a, b));
+        //is_bounded(<T as Trait>::dft_assoc_async_method_no_ret(&x, a, b));
+        //is_bounded(<T as Trait>::dft_assoc_async_fn(a, b));
+        //is_bounded(<T as Trait>::dft_assoc_async_method(&x, a, b));
+    }
+    inner(());
+}

--- a/trait-variant/tests/colon-bounds.rs
+++ b/trait-variant/tests/colon-bounds.rs
@@ -1,0 +1,65 @@
+// Copyright (c) 2023 Google LLC
+// Copyright (c) 2023 Various contributors (see git history)
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[trait_variant::make(: Send + Sync)]
+pub trait Trait {
+    const CONST: &'static ();
+    type Gat<'a>
+    where
+        Self: 'a;
+    async fn assoc_async_fn_no_ret(a: (), b: ());
+    async fn assoc_async_method_no_ret(&self, a: (), b: ());
+    async fn assoc_async_fn(a: (), b: ()) -> ();
+    async fn assoc_async_method(&self, a: (), b: ()) -> ();
+    fn assoc_sync_fn_no_ret(a: (), b: ());
+    fn assoc_sync_method_no_ret(&self, a: (), b: ());
+    fn assoc_sync_fn(a: (), b: ()) -> ();
+    fn assoc_sync_method(&self, a: (), b: ()) -> ();
+    // FIXME: See #17.
+    //async fn dft_assoc_async_fn_no_ret(_a: (), _b: ()) {}
+    //async fn dft_assoc_async_method_no_ret(&self, _a: (), _b: ()) {}
+    //async fn dft_assoc_async_fn(_a: (), _b: ()) -> () {}
+    //async fn dft_assoc_async_method(&self, _a: (), _b: ()) -> () {}
+    fn dft_assoc_sync_fn_no_ret(_a: (), _b: ()) {}
+    fn dft_assoc_sync_method_no_ret(&self, _a: (), _b: ()) {}
+    fn dft_assoc_sync_fn(_a: (), _b: ()) -> () {}
+    fn dft_assoc_sync_method(&self, _a: (), _b: ()) -> () {}
+}
+
+impl Trait for () {
+    const CONST: &'static () = &();
+    type Gat<'a> = ();
+    async fn assoc_async_fn_no_ret(_a: (), _b: ()) {}
+    async fn assoc_async_method_no_ret(&self, _a: (), _b: ()) {}
+    async fn assoc_async_fn(_a: (), _b: ()) -> () {}
+    async fn assoc_async_method(&self, _a: (), _b: ()) -> () {}
+    fn assoc_sync_fn_no_ret(_a: (), _b: ()) {}
+    fn assoc_sync_method_no_ret(&self, _a: (), _b: ()) {}
+    fn assoc_sync_fn(_a: (), _b: ()) -> () {}
+    fn assoc_sync_method(&self, _a: (), _b: ()) -> () {}
+}
+
+fn is_bounded<T: Send + Sync>(_: T) {}
+
+#[test]
+fn test() {
+    fn inner<T: Trait>(x: T) {
+        let (a, b) = ((), ());
+        is_bounded(<T as Trait>::assoc_async_fn_no_ret(a, b));
+        is_bounded(<T as Trait>::assoc_async_method_no_ret(&x, a, b));
+        is_bounded(<T as Trait>::assoc_async_fn(a, b));
+        is_bounded(<T as Trait>::assoc_async_method(&x, a, b));
+        // FIXME: See #17.
+        //is_bounded(<T as Trait>::dft_assoc_async_fn_no_ret(a, b));
+        //is_bounded(<T as Trait>::dft_assoc_async_method_no_ret(&x, a, b));
+        //is_bounded(<T as Trait>::dft_assoc_async_fn(a, b));
+        //is_bounded(<T as Trait>::dft_assoc_async_method(&x, a, b));
+    }
+    inner(());
+}

--- a/trait-variant/tests/name-colon-bounds.rs
+++ b/trait-variant/tests/name-colon-bounds.rs
@@ -1,0 +1,65 @@
+// Copyright (c) 2023 Google LLC
+// Copyright (c) 2023 Various contributors (see git history)
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[trait_variant::make(Trait: Send + Sync)]
+pub trait LocalTrait {
+    const CONST: &'static ();
+    type Gat<'a>
+    where
+        Self: 'a;
+    async fn assoc_async_fn_no_ret(a: (), b: ());
+    async fn assoc_async_method_no_ret(&self, a: (), b: ());
+    async fn assoc_async_fn(a: (), b: ()) -> ();
+    async fn assoc_async_method(&self, a: (), b: ()) -> ();
+    fn assoc_sync_fn_no_ret(a: (), b: ());
+    fn assoc_sync_method_no_ret(&self, a: (), b: ());
+    fn assoc_sync_fn(a: (), b: ()) -> ();
+    fn assoc_sync_method(&self, a: (), b: ()) -> ();
+    // FIXME: See #17.
+    //async fn dft_assoc_async_fn_no_ret(_a: (), _b: ()) {}
+    //async fn dft_assoc_async_method_no_ret(&self, _a: (), _b: ()) {}
+    //async fn dft_assoc_async_fn(_a: (), _b: ()) -> () {}
+    //async fn dft_assoc_async_method(&self, _a: (), _b: ()) -> () {}
+    fn dft_assoc_sync_fn_no_ret(_a: (), _b: ()) {}
+    fn dft_assoc_sync_method_no_ret(&self, _a: (), _b: ()) {}
+    fn dft_assoc_sync_fn(_a: (), _b: ()) -> () {}
+    fn dft_assoc_sync_method(&self, _a: (), _b: ()) -> () {}
+}
+
+impl Trait for () {
+    const CONST: &'static () = &();
+    type Gat<'a> = ();
+    async fn assoc_async_fn_no_ret(_a: (), _b: ()) {}
+    async fn assoc_async_method_no_ret(&self, _a: (), _b: ()) {}
+    async fn assoc_async_fn(_a: (), _b: ()) -> () {}
+    async fn assoc_async_method(&self, _a: (), _b: ()) -> () {}
+    fn assoc_sync_fn_no_ret(_a: (), _b: ()) {}
+    fn assoc_sync_method_no_ret(&self, _a: (), _b: ()) {}
+    fn assoc_sync_fn(_a: (), _b: ()) -> () {}
+    fn assoc_sync_method(&self, _a: (), _b: ()) -> () {}
+}
+
+fn is_bounded<T: Send + Sync>(_: T) {}
+
+#[test]
+fn test() {
+    fn inner<T: Trait>(x: T) {
+        let (a, b) = ((), ());
+        is_bounded(<T as Trait>::assoc_async_fn_no_ret(a, b));
+        is_bounded(<T as Trait>::assoc_async_method_no_ret(&x, a, b));
+        is_bounded(<T as Trait>::assoc_async_fn(a, b));
+        is_bounded(<T as Trait>::assoc_async_method(&x, a, b));
+        // FIXME: See #17.
+        //is_bounded(<T as Trait>::dft_assoc_async_fn_no_ret(a, b));
+        //is_bounded(<T as Trait>::dft_assoc_async_method_no_ret(&x, a, b));
+        //is_bounded(<T as Trait>::dft_assoc_async_fn(a, b));
+        //is_bounded(<T as Trait>::dft_assoc_async_method(&x, a, b));
+    }
+    inner(());
+}

--- a/trait-variant/tests/name-colon.rs
+++ b/trait-variant/tests/name-colon.rs
@@ -1,0 +1,66 @@
+// Copyright (c) 2023 Google LLC
+// Copyright (c) 2023 Various contributors (see git history)
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[trait_variant::make(Trait:)]
+#[allow(async_fn_in_trait)]
+pub trait LocalTrait {
+    const CONST: &'static ();
+    type Gat<'a>
+    where
+        Self: 'a;
+    async fn assoc_async_fn_no_ret(a: (), b: ());
+    async fn assoc_async_method_no_ret(&self, a: (), b: ());
+    async fn assoc_async_fn(a: (), b: ()) -> ();
+    async fn assoc_async_method(&self, a: (), b: ()) -> ();
+    fn assoc_sync_fn_no_ret(a: (), b: ());
+    fn assoc_sync_method_no_ret(&self, a: (), b: ());
+    fn assoc_sync_fn(a: (), b: ()) -> ();
+    fn assoc_sync_method(&self, a: (), b: ()) -> ();
+    // FIXME: See #17.
+    //async fn dft_assoc_async_fn_no_ret(_a: (), _b: ()) {}
+    //async fn dft_assoc_async_method_no_ret(&self, _a: (), _b: ()) {}
+    //async fn dft_assoc_async_fn(_a: (), _b: ()) -> () {}
+    //async fn dft_assoc_async_method(&self, _a: (), _b: ()) -> () {}
+    fn dft_assoc_sync_fn_no_ret(_a: (), _b: ()) {}
+    fn dft_assoc_sync_method_no_ret(&self, _a: (), _b: ()) {}
+    fn dft_assoc_sync_fn(_a: (), _b: ()) -> () {}
+    fn dft_assoc_sync_method(&self, _a: (), _b: ()) -> () {}
+}
+
+impl Trait for () {
+    const CONST: &'static () = &();
+    type Gat<'a> = ();
+    async fn assoc_async_fn_no_ret(_a: (), _b: ()) {}
+    async fn assoc_async_method_no_ret(&self, _a: (), _b: ()) {}
+    async fn assoc_async_fn(_a: (), _b: ()) -> () {}
+    async fn assoc_async_method(&self, _a: (), _b: ()) -> () {}
+    fn assoc_sync_fn_no_ret(_a: (), _b: ()) {}
+    fn assoc_sync_method_no_ret(&self, _a: (), _b: ()) {}
+    fn assoc_sync_fn(_a: (), _b: ()) -> () {}
+    fn assoc_sync_method(&self, _a: (), _b: ()) -> () {}
+}
+
+fn is_bounded<T>(_: T) {}
+
+#[test]
+fn test() {
+    fn inner<T: Trait>(x: T) {
+        let (a, b) = ((), ());
+        is_bounded(<T as Trait>::assoc_async_fn_no_ret(a, b));
+        is_bounded(<T as Trait>::assoc_async_method_no_ret(&x, a, b));
+        is_bounded(<T as Trait>::assoc_async_fn(a, b));
+        is_bounded(<T as Trait>::assoc_async_method(&x, a, b));
+        // FIXME: See #17.
+        //is_bounded(<T as Trait>::dft_assoc_async_fn_no_ret(a, b));
+        //is_bounded(<T as Trait>::dft_assoc_async_method_no_ret(&x, a, b));
+        //is_bounded(<T as Trait>::dft_assoc_async_fn(a, b));
+        //is_bounded(<T as Trait>::dft_assoc_async_method(&x, a, b));
+    }
+    inner(());
+}

--- a/trait-variant/tests/same_name-colon-bounds.rs
+++ b/trait-variant/tests/same_name-colon-bounds.rs
@@ -1,0 +1,65 @@
+// Copyright (c) 2023 Google LLC
+// Copyright (c) 2023 Various contributors (see git history)
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[trait_variant::make(Trait: Send + Sync)]
+pub trait Trait {
+    const CONST: &'static ();
+    type Gat<'a>
+    where
+        Self: 'a;
+    async fn assoc_async_fn_no_ret(a: (), b: ());
+    async fn assoc_async_method_no_ret(&self, a: (), b: ());
+    async fn assoc_async_fn(a: (), b: ()) -> ();
+    async fn assoc_async_method(&self, a: (), b: ()) -> ();
+    fn assoc_sync_fn_no_ret(a: (), b: ());
+    fn assoc_sync_method_no_ret(&self, a: (), b: ());
+    fn assoc_sync_fn(a: (), b: ()) -> ();
+    fn assoc_sync_method(&self, a: (), b: ()) -> ();
+    // FIXME: See #17.
+    //async fn dft_assoc_async_fn_no_ret(_a: (), _b: ()) {}
+    //async fn dft_assoc_async_method_no_ret(&self, _a: (), _b: ()) {}
+    //async fn dft_assoc_async_fn(_a: (), _b: ()) -> () {}
+    //async fn dft_assoc_async_method(&self, _a: (), _b: ()) -> () {}
+    fn dft_assoc_sync_fn_no_ret(_a: (), _b: ()) {}
+    fn dft_assoc_sync_method_no_ret(&self, _a: (), _b: ()) {}
+    fn dft_assoc_sync_fn(_a: (), _b: ()) -> () {}
+    fn dft_assoc_sync_method(&self, _a: (), _b: ()) -> () {}
+}
+
+impl Trait for () {
+    const CONST: &'static () = &();
+    type Gat<'a> = ();
+    async fn assoc_async_fn_no_ret(_a: (), _b: ()) {}
+    async fn assoc_async_method_no_ret(&self, _a: (), _b: ()) {}
+    async fn assoc_async_fn(_a: (), _b: ()) -> () {}
+    async fn assoc_async_method(&self, _a: (), _b: ()) -> () {}
+    fn assoc_sync_fn_no_ret(_a: (), _b: ()) {}
+    fn assoc_sync_method_no_ret(&self, _a: (), _b: ()) {}
+    fn assoc_sync_fn(_a: (), _b: ()) -> () {}
+    fn assoc_sync_method(&self, _a: (), _b: ()) -> () {}
+}
+
+fn is_bounded<T: Send + Sync>(_: T) {}
+
+#[test]
+fn test() {
+    fn inner<T: Trait>(x: T) {
+        let (a, b) = ((), ());
+        is_bounded(<T as Trait>::assoc_async_fn_no_ret(a, b));
+        is_bounded(<T as Trait>::assoc_async_method_no_ret(&x, a, b));
+        is_bounded(<T as Trait>::assoc_async_fn(a, b));
+        is_bounded(<T as Trait>::assoc_async_method(&x, a, b));
+        // FIXME: See #17.
+        //is_bounded(<T as Trait>::dft_assoc_async_fn_no_ret(a, b));
+        //is_bounded(<T as Trait>::dft_assoc_async_method_no_ret(&x, a, b));
+        //is_bounded(<T as Trait>::dft_assoc_async_fn(a, b));
+        //is_bounded(<T as Trait>::dft_assoc_async_method(&x, a, b));
+    }
+    inner(());
+}


### PR DESCRIPTION
Let's say that we want to create a `Send` variant of a trait but we don't need a non-`Send` variant of that trait at all.  We could of course just write that trait, but adding the `Send` bounds in all the right places could be annoying.

In this commit, we allow simply omitting the new variant name from the call to `make`.  When called that way, we use the name from the item to emit only one variant with the bounds applied.  We don't emit the original item.

For completeness and explicit disambiguation, we support prefixing the bounds with a colon (but giving no variant name).  Similarly, for completeness, we support giving the same name as the trait item.  In both of these cases, we just emit the one variant.  Since these are for completeness, we don't advertise these syntaxes in the documentation.

That is, we now support:

- `make(NAME: BOUNDS)`
- `make(NAME:)`
- `make(:BOUNDS)`
- `make(BOUNDS)`

This resolves #18.