### PR TITLE
Include license files in cargo package

### DIFF
--- a/trait-transformer/LICENSE-APACHE
+++ b/trait-transformer/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/trait-transformer/LICENSE-MIT
+++ b/trait-transformer/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/trait-variant/LICENSE-APACHE
+++ b/trait-variant/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/trait-variant/LICENSE-MIT
+++ b/trait-variant/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
This makes sure that the LICENSE-APACHE and LICENSE-MIT files will be included in the next release of the crates.